### PR TITLE
Multiple LEDs [2/3]: Illumination Bars support

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -477,6 +477,7 @@
     <string name="notification_light_voicemail_title">Voicemail</string>
     <string name="notification_light_brightness" translatable="false">@string/brightness</string>
     <string name="notification_light_screen_on">Lights with screen on</string>
+    <string name="notification_light_use_multiple_leds">Multiple LEDs</string>
     <string name="keywords_lights_brightness_level">dim leds brightness</string>
 
     <!-- Sound & notification > Sound section: Title for the option defining the default notification ringtone. [CHAR LIMIT=30] -->

--- a/res/xml/notification_light_settings.xml
+++ b/res/xml/notification_light_settings.xml
@@ -46,6 +46,11 @@
         </PreferenceScreen>
 
         <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
+            android:key="notification_light_multiple_leds_enable"
+            android:title="@string/notification_light_use_multiple_leds"
+            android:dependency="notification_light_pulse" />
+
+        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
             android:key="notification_light_screen_on_enable"
             android:title="@string/notification_light_screen_on"
             android:dependency="notification_light_pulse" />

--- a/src/com/android/settings/notificationlight/NotificationLightSettings.java
+++ b/src/com/android/settings/notificationlight/NotificationLightSettings.java
@@ -80,6 +80,7 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
     private PreferenceScreen mNotificationLedBrightnessPref;
     private SystemSettingSwitchPreference mEnabledPref;
     private SystemSettingSwitchPreference mCustomEnabledPref;
+    private SystemSettingSwitchPreference mMultipleLedsEnabledPref;
     private SystemSettingSwitchPreference mScreenOnLightsPref;
     private ApplicationLightPreference mDefaultPref;
     private ApplicationLightPreference mCallPref;
@@ -118,6 +119,8 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         // Advanced light settings
         mNotificationLedBrightnessPref = (PreferenceScreen)
                 findPreference(Settings.System.NOTIFICATION_LIGHT_BRIGHTNESS_LEVEL);
+        mMultipleLedsEnabledPref = (SystemSettingSwitchPreference)
+                findPreference(Settings.System.NOTIFICATION_LIGHT_MULTIPLE_LEDS_ENABLE);
         mScreenOnLightsPref = (SystemSettingSwitchPreference)
                 findPreference(Settings.System.NOTIFICATION_LIGHT_SCREEN_ON);
         mScreenOnLightsPref.setOnPreferenceChangeListener(this);
@@ -129,6 +132,12 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
             mAdvancedPrefs.removePreference(mNotificationLedBrightnessPref);
         } else {
             mNotificationLedBrightnessPref.setOnPreferenceChangeListener(this);
+        }
+        if (!resources.getBoolean(
+                com.android.internal.R.bool.config_multipleNotificationLeds)) {
+            mAdvancedPrefs.removePreference(mMultipleLedsEnabledPref);
+        } else {
+            mMultipleLedsEnabledPref.setOnPreferenceChangeListener(this);
         }
 
         // Missed call and Voicemail preferences should only show on devices with a voice capabilities
@@ -400,6 +409,7 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
 
     public boolean onPreferenceChange(Preference preference, Object objValue) {
         if (preference == mEnabledPref || preference == mCustomEnabledPref ||
+                preference == mMultipleLedsEnabledPref ||
                 preference == mNotificationLedBrightnessPref ||
                 preference == mScreenOnLightsPref) {
             getActivity().invalidateOptionsMenu();


### PR DESCRIPTION
Implement the support of a multiple LEDs settings.

The setting is deactivated by default
and will be ignored by the unimplemented phones.
Current LibLights will simply not use the new variable.

Changes includes :
  frameworks/base
  hardware/libhardware
  packages/Apps/Settings

Change-Id: I5531093cd0543d7730a8c3f83c0aebb3678436d5
Signed-off-by: AdrianDC radian.dc@gmail.com
