### PR TITLE
Tethering: Turn off Wi-Fi Hotspot after inactivity (3/3)

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -610,4 +610,19 @@
         <item>2</item>
     </string-array>
 
+    <!-- Wi-Fi tethering inactivity shut off -->
+    <string-array name="hotstpot_inactivity_timeout_entries" translatable="false">
+        <item>@string/hotstpot_inactivity_timeout_never</item>
+        <item>@string/hotstpot_inactivity_timeout_1_minute</item>
+        <item>@string/hotstpot_inactivity_timeout_5_minutes</item>
+        <item>@string/hotstpot_inactivity_timeout_10_minutes</item>
+    </string-array>
+
+    <string-array name="hotstpot_inactivity_timeout_values" translatable="false">
+        <item>0</item>
+        <item>60000</item>
+        <item>300000</item>
+        <item>600000</item>
+    </string-array>
+
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1070,4 +1070,15 @@
     <string name="factory_reset_erase_sd_card_summary">Erase all data on the SD card, including music and photos</string>
     <string name="factory_reset_warning_text_reset_now">RESET NOW</string>
     <string name="factory_reset_warning_text_message">All your accounts, apps, app data, and system settings will be removed from this device. This cannot be reversed.</string>
+
+    <!-- Tethering & portable hotspot other category -->
+    <string name="tethering_other_category_text">Other</string>
+    <!-- Wi-Fi tethering inactivity timeout -->
+    <string name="hotstpot_inactivity_timeout_text">Wi\u2011Fi hotspot timeout</string>
+    <string name="hotstpot_inactivity_timeout_never">Never</string>
+    <string name="hotstpot_inactivity_timeout_1_minute">1 minute</string>
+    <string name="hotstpot_inactivity_timeout_5_minutes">5 minutes</string>
+    <string name="hotstpot_inactivity_timeout_10_minutes">10 minutes</string>
+    <string name="hotstpot_inactivity_timeout_never_summary_text">Portable Wi\u2011Fi hotspot timeout never</string>
+    <string name="hotstpot_inactivity_timeout_summary_text">Portable Wi\u2011Fi hotspot timeout after <xliff:g id="timeout">%1$s</xliff:g></string>
 </resources>

--- a/res/xml/tether_prefs.xml
+++ b/res/xml/tether_prefs.xml
@@ -26,14 +26,26 @@
         android:title="@string/wifi_tether_configure_ap_text"
         android:persistent="false" />
 
-    <SwitchPreference
-        android:key="usb_tether_settings"
-        android:title="@string/usb_tethering_button_text"
+    <ListPreference
+        android:key="hotstpot_inactivity_timeout"
+        android:title="@string/hotstpot_inactivity_timeout_text"
+        android:entries="@array/hotstpot_inactivity_timeout_entries"
+        android:entryValues="@array/hotstpot_inactivity_timeout_values"
         android:persistent="false" />
 
-    <SwitchPreference
-        android:key="enable_bluetooth_tethering"
-        android:title="@string/bluetooth_tether_checkbox_text"
-        android:persistent="false" />
+    <PreferenceCategory
+        android:title="@string/tethering_other_category_text">
+
+        <SwitchPreference
+            android:key="usb_tether_settings"
+            android:title="@string/usb_tethering_button_text"
+            android:persistent="false" />
+
+        <SwitchPreference
+            android:key="enable_bluetooth_tethering"
+            android:title="@string/bluetooth_tether_checkbox_text"
+            android:persistent="false" />
+
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Turn off the Wi-Fi hotspot after a specified time of inactivity.
The hotspot is considered to be inactive when no clients are
connected to it.

Change-Id: I7030e702328726b72f394b2a64b93830dba54efc
